### PR TITLE
feat: add complete support center with Jira integration v1.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wowkeyb-fe",
-    "version": "1.26.0",
+    "version": "1.27.0",
     "description": "World of Warcraft - Wow Keybinding",
     "author": "Logan Born",
     "license": "https://themeforest.net/licenses/standard",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -69,6 +69,18 @@ export const appRoutes: Route[] = [
         ]
     },
 
+    // Support routes
+    {
+        path: '',
+        component: LayoutComponent,
+        data: {
+            layout: 'modern'
+        },
+        children: [
+            { path: 'support', loadChildren: () => import('app/modules/support/support.routes') },
+        ]
+    },
+
     // Profile route (without initialDataResolver to avoid hanging)
     {
         path: '',

--- a/src/app/layout/layouts/horizontal/modern/modern.component.html
+++ b/src/app/layout/layouts/horizontal/modern/modern.component.html
@@ -57,11 +57,17 @@
             <button class="lg:hidden" mat-icon-button (click)="quickChat.toggle()">
                 <mat-icon [svgIcon]="'heroicons_outline:chat-bubble-left-right'"></mat-icon>
             </button> -->
+            <button mat-icon-button [routerLink]="['/support']" matTooltip="Support">
+                <mat-icon [svgIcon]="'heroicons_outline:question-mark-circle'"></mat-icon>
+            </button>
             <user></user>
         </div>
         }
         @if(!isAuthenticated) {
         <div class="ml-auto flex items-center space-x-0.5 pl-2 sm:space-x-2">
+            <button mat-icon-button [routerLink]="['/support']" matTooltip="Support">
+                <mat-icon [svgIcon]="'heroicons_outline:question-mark-circle'"></mat-icon>
+            </button>
             <button mat-flat-button (click)="goToLogin()">
                 Login
             </button>

--- a/src/app/layout/layouts/horizontal/modern/modern.component.ts
+++ b/src/app/layout/layouts/horizontal/modern/modern.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { FuseFullscreenComponent } from '@fuse/components/fullscreen';
@@ -36,6 +37,7 @@ import packageJson from '../../../../../../package.json'
         FuseHorizontalNavigationComponent,
         MatButtonModule,
         MatIconModule,
+        MatTooltipModule,
         RouterModule,
         LanguagesComponent,
         FuseFullscreenComponent,

--- a/src/app/modules/support/faq/faq.component.html
+++ b/src/app/modules/support/faq/faq.component.html
@@ -1,0 +1,59 @@
+<div class="flex w-full flex-auto flex-col">
+    <!-- Header -->
+    <div class="bg-card dark:bg-transparent relative overflow-hidden px-4 py-12 sm:px-16 sm:py-16">
+        <div class="relative z-10 mx-auto flex w-full max-w-6xl flex-col">
+            <button mat-button [routerLink]="['/support']" class="mb-4 self-start">
+                <mat-icon [svgIcon]="'heroicons_outline:arrow-left'" class="mr-2"></mat-icon>
+                Back to Support
+            </button>
+            <h1 class="text-4xl font-extrabold leading-tight tracking-tight sm:text-6xl">
+                Frequently Asked Questions
+            </h1>
+            <div class="text-secondary mt-3 text-lg tracking-tight">
+                Find quick answers to common questions
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="mx-auto w-full max-w-6xl px-4 py-10 sm:px-16 sm:py-14">
+        <!-- Category Filter -->
+        <div class="mb-8 flex flex-wrap gap-2">
+            @for (category of faqCategories; track category) {
+            <button mat-stroked-button [color]="selectedCategory === category ? 'primary' : ''"
+                (click)="selectCategory(category)" class="min-w-[100px]">
+                {{ category }}
+            </button>
+            }
+        </div>
+
+        <!-- FAQ Accordion -->
+        <mat-accordion class="faq-accordion">
+            @for (faq of filteredFaqs; track faq.question) {
+            <mat-expansion-panel class="mb-4">
+                <mat-expansion-panel-header>
+                    <mat-panel-title class="text-lg font-semibold">
+                        {{ faq.question }}
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+                <p class="text-secondary leading-relaxed">
+                    {{ faq.answer }}
+                </p>
+            </mat-expansion-panel>
+            }
+        </mat-accordion>
+
+        <!-- Still need help? -->
+        <div class="bg-card dark:bg-transparent mt-12 rounded-lg border p-8 text-center">
+            <mat-icon class="text-primary mb-4" [svgIcon]="'heroicons_outline:chat-bubble-left-right'"
+                style="width: 48px; height: 48px;"></mat-icon>
+            <h2 class="text-2xl font-semibold mb-4">Still need help?</h2>
+            <p class="text-secondary mb-6">
+                Can't find what you're looking for? Our support team is here to help.
+            </p>
+            <button mat-flat-button color="primary" [routerLink]="['/support/ticket']">
+                Submit Support Ticket
+            </button>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/support/faq/faq.component.ts
+++ b/src/app/modules/support/faq/faq.component.ts
@@ -1,0 +1,140 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { RouterLink } from '@angular/router';
+
+interface FaqItem {
+    question: string;
+    answer: string;
+    category: string;
+}
+
+@Component({
+    selector: 'app-faq',
+    templateUrl: './faq.component.html',
+    standalone: true,
+    imports: [
+        CommonModule,
+        MatButtonModule,
+        MatIconModule,
+        MatExpansionModule,
+        RouterLink
+    ]
+})
+export class FaqComponent {
+    faqCategories = ['General', 'Keybinds', 'Macros', 'Account', 'Technical'];
+    selectedCategory = 'General';
+
+    faqItems: FaqItem[] = [
+        // General
+        {
+            category: 'General',
+            question: 'What is WowKeyb?',
+            answer: 'WowKeyb is a comprehensive tool for managing World of Warcraft keybindings and macros. It allows you to create, share, and discover optimized keybind setups and macros for all classes and specs.'
+        },
+        {
+            category: 'General',
+            question: 'Is WowKeyb free to use?',
+            answer: 'Yes, WowKeyb is completely free to use. You can create an account, save your keybinds and macros, and access all features without any cost.'
+        },
+        {
+            category: 'General',
+            question: 'How do I get started?',
+            answer: 'Simply create an account, browse the keybind library or macro library, and start customizing your setup. You can also create your own keybinds and macros from scratch.'
+        },
+
+        // Keybinds
+        {
+            category: 'Keybinds',
+            question: 'How do I import keybinds into WoW?',
+            answer: 'After creating or selecting a keybind setup, click the "Export" button to download the keybind file. Place this file in your WoW folder: World of Warcraft/_retail_/WTF/Account/[ACCOUNT_NAME]/. Then use the in-game command "/console cvar_default" to load them.'
+        },
+        {
+            category: 'Keybinds',
+            question: 'Can I share my keybinds with others?',
+            answer: 'Yes! All keybind setups can be shared using the share button. This generates a unique link that others can use to view and copy your setup.'
+        },
+        {
+            category: 'Keybinds',
+            question: 'How do I filter keybinds by class?',
+            answer: 'Use the filter dropdown on the keybinds page to select your class and spec. This will show you optimized setups specifically designed for your character.'
+        },
+        {
+            category: 'Keybinds',
+            question: 'Can I customize existing keybind setups?',
+            answer: 'Absolutely! You can clone any existing setup and modify it to fit your preferences. Your customized version will be saved to your account.'
+        },
+
+        // Macros
+        {
+            category: 'Macros',
+            question: 'What types of macros can I create?',
+            answer: 'WowKeyb supports all World of Warcraft macro types including general macros, class-specific macros, and spec-specific macros. You can use the macro builder to create complex macros with conditions.'
+        },
+        {
+            category: 'Macros',
+            question: 'How long can a macro be?',
+            answer: 'Following WoW\'s limitations, macros can be up to 255 characters. The macro builder will show you the character count as you create your macro.'
+        },
+        {
+            category: 'Macros',
+            question: 'Can I test my macros before exporting?',
+            answer: 'Yes, the macro validator will check your macro for common errors and syntax issues before you save or export it.'
+        },
+        {
+            category: 'Macros',
+            question: 'How do I import macros into WoW?',
+            answer: 'Copy the macro text from WowKeyb, then in WoW, open the macro panel (press Esc > Macros), click "New", paste the text, and save.'
+        },
+
+        // Account
+        {
+            category: 'Account',
+            question: 'How do I reset my password?',
+            answer: 'Click on "Forgot Password" on the login page. Enter your email address and we\'ll send you instructions to reset your password.'
+        },
+        {
+            category: 'Account',
+            question: 'Can I delete my account?',
+            answer: 'Yes, you can delete your account from the Settings page. Please note that this action is permanent and will delete all your saved keybinds and macros.'
+        },
+        {
+            category: 'Account',
+            question: 'How do I change my email address?',
+            answer: 'Go to Settings > Account Settings to update your email address. You\'ll need to verify the new email address before the change takes effect.'
+        },
+
+        // Technical
+        {
+            category: 'Technical',
+            question: 'Which browsers are supported?',
+            answer: 'WowKeyb works best on modern browsers including Chrome, Firefox, Safari, and Edge. We recommend keeping your browser up to date for the best experience.'
+        },
+        {
+            category: 'Technical',
+            question: 'Is my data secure?',
+            answer: 'Yes, we take security seriously. All data is encrypted in transit and at rest. We never share your personal information with third parties.'
+        },
+        {
+            category: 'Technical',
+            question: 'Can I use WowKeyb on mobile?',
+            answer: 'Yes, WowKeyb is fully responsive and works on mobile devices. However, for the best experience creating and editing keybinds, we recommend using a desktop browser.'
+        },
+        {
+            category: 'Technical',
+            question: 'I found a bug, how do I report it?',
+            answer: 'Please submit a support ticket with details about the bug including what you were doing when it occurred, your browser version, and any error messages you saw.'
+        }
+    ];
+
+    get filteredFaqs(): FaqItem[] {
+        return this.faqItems.filter(item => item.category === this.selectedCategory);
+    }
+
+    selectCategory(category: string): void {
+        this.selectedCategory = category;
+    }
+}
+

--- a/src/app/modules/support/support.component.html
+++ b/src/app/modules/support/support.component.html
@@ -1,0 +1,81 @@
+<div class="flex w-full flex-auto flex-col">
+    <!-- Header -->
+    <div class="bg-card dark:bg-transparent relative overflow-hidden px-4 py-12 sm:px-16 sm:py-20">
+        <div class="relative z-10 mx-auto flex w-full max-w-6xl flex-col items-center">
+            <h1 class="text-4xl font-extrabold leading-tight tracking-tight sm:text-7xl">
+                Support Center
+            </h1>
+            <div class="text-secondary mt-3 text-lg tracking-tight sm:text-2xl">
+                We're here to help you get the most out of WowKeyb
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="mx-auto w-full max-w-6xl px-4 py-10 sm:px-16 sm:py-14">
+        <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
+            <!-- FAQ Card -->
+            <mat-card class="flex flex-col p-8 hover:shadow-lg transition-shadow cursor-pointer"
+                [routerLink]="['/support/faq']">
+                <div class="flex items-center mb-4">
+                    <mat-icon class="text-blue-600 mr-3" [svgIcon]="'heroicons_outline:question-mark-circle'"
+                        style="width: 48px; height: 48px;"></mat-icon>
+                    <h2 class="text-2xl font-semibold">Frequently Asked Questions</h2>
+                </div>
+                <p class="text-secondary mb-4 flex-1">
+                    Find answers to common questions about keybinds, macros, and using WowKeyb effectively.
+                </p>
+                <button mat-flat-button color="primary" class="w-full">
+                    Browse FAQ
+                    <mat-icon class="ml-2" [svgIcon]="'heroicons_outline:arrow-right'"></mat-icon>
+                </button>
+            </mat-card>
+
+            <!-- Support Ticket Card -->
+            <mat-card class="flex flex-col p-8 hover:shadow-lg transition-shadow cursor-pointer"
+                [routerLink]="['/support/ticket']">
+                <div class="flex items-center mb-4">
+                    <mat-icon class="text-green-600 mr-3" [svgIcon]="'heroicons_outline:ticket'"
+                        style="width: 48px; height: 48px;"></mat-icon>
+                    <h2 class="text-2xl font-semibold">Submit Support Ticket</h2>
+                </div>
+                <p class="text-secondary mb-4 flex-1">
+                    Can't find what you're looking for? Submit a support ticket and our team will get back to you.
+                </p>
+                <button mat-flat-button color="primary" class="w-full">
+                    Create Ticket
+                    <mat-icon class="ml-2" [svgIcon]="'heroicons_outline:arrow-right'"></mat-icon>
+                </button>
+            </mat-card>
+        </div>
+
+        <!-- Additional Resources -->
+        <div class="mt-12">
+            <h2 class="text-2xl font-semibold mb-6">Additional Resources</h2>
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div class="bg-card dark:bg-transparent rounded-lg border p-6">
+                    <mat-icon class="text-purple-600 mb-3" [svgIcon]="'heroicons_outline:book-open'"></mat-icon>
+                    <h3 class="text-lg font-semibold mb-2">Documentation</h3>
+                    <p class="text-secondary text-sm">
+                        Comprehensive guides and tutorials for all features.
+                    </p>
+                </div>
+                <div class="bg-card dark:bg-transparent rounded-lg border p-6">
+                    <mat-icon class="text-orange-600 mb-3"
+                        [svgIcon]="'heroicons_outline:chat-bubble-left-right'"></mat-icon>
+                    <h3 class="text-lg font-semibold mb-2">Community</h3>
+                    <p class="text-secondary text-sm">
+                        Connect with other users and share your setups.
+                    </p>
+                </div>
+                <div class="bg-card dark:bg-transparent rounded-lg border p-6">
+                    <mat-icon class="text-red-600 mb-3" [svgIcon]="'heroicons_outline:video-camera'"></mat-icon>
+                    <h3 class="text-lg font-semibold mb-2">Video Tutorials</h3>
+                    <p class="text-secondary text-sm">
+                        Watch step-by-step video guides for common tasks.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/support/support.component.ts
+++ b/src/app/modules/support/support.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { RouterLink } from '@angular/router';
+import { AuthService } from 'app/core/auth/auth.service';
+
+@Component({
+    selector: 'app-support',
+    templateUrl: './support.component.html',
+    standalone: true,
+    imports: [
+        CommonModule,
+        MatButtonModule,
+        MatIconModule,
+        MatCardModule,
+        RouterLink
+    ]
+})
+export class SupportComponent implements OnInit {
+    isAuthenticated = false;
+
+    constructor(private _authService: AuthService) { }
+
+    ngOnInit(): void {
+        this._authService.check().subscribe(authenticated => {
+            this.isAuthenticated = authenticated;
+        });
+    }
+}
+

--- a/src/app/modules/support/support.routes.ts
+++ b/src/app/modules/support/support.routes.ts
@@ -1,0 +1,18 @@
+import { Routes } from '@angular/router';
+import { SupportComponent } from './support.component';
+
+export default [
+    {
+        path: '',
+        component: SupportComponent,
+    },
+    {
+        path: 'faq',
+        loadComponent: () => import('./faq/faq.component').then(m => m.FaqComponent),
+    },
+    {
+        path: 'ticket',
+        loadComponent: () => import('./ticket/ticket.component').then(m => m.TicketComponent),
+    }
+] as Routes;
+

--- a/src/app/modules/support/ticket/ticket.component.html
+++ b/src/app/modules/support/ticket/ticket.component.html
@@ -1,0 +1,141 @@
+<div class="flex w-full flex-auto flex-col">
+    <!-- Header -->
+    <div class="bg-card dark:bg-transparent relative overflow-hidden px-4 py-12 sm:px-16 sm:py-16">
+        <div class="relative z-10 mx-auto flex w-full max-w-6xl flex-col">
+            <button mat-button [routerLink]="['/support']" class="mb-4 self-start">
+                <mat-icon [svgIcon]="'heroicons_outline:arrow-left'" class="mr-2"></mat-icon>
+                Back to Support
+            </button>
+            <h1 class="text-4xl font-extrabold leading-tight tracking-tight sm:text-6xl">
+                Submit Support Ticket
+            </h1>
+            <div class="text-secondary mt-3 text-lg tracking-tight">
+                Our team will respond within 24-48 hours
+            </div>
+        </div>
+    </div>
+
+    <!-- Content -->
+    <div class="mx-auto w-full max-w-4xl px-4 py-10 sm:px-16 sm:py-14">
+        @if (!submitted) {
+        <!-- Info Box -->
+        <div class="bg-blue-50 dark:bg-blue-900/20 mb-8 rounded-lg border border-blue-200 dark:border-blue-800 p-6">
+            <div class="flex items-start">
+                <mat-icon class="text-blue-600 mr-3 mt-1" [svgIcon]="'heroicons_outline:information-circle'"></mat-icon>
+                <div>
+                    <h3 class="text-lg font-semibold mb-2">Before submitting a ticket</h3>
+                    <ul class="text-secondary text-sm space-y-1 list-disc list-inside">
+                        <li>Check our <a [routerLink]="['/support/faq']" class="text-blue-600 hover:underline">FAQ
+                                page</a> for quick answers</li>
+                        <li>Provide as much detail as possible to help us resolve your issue faster</li>
+                        <li>Include screenshots or error messages if applicable</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <!-- Ticket Form -->
+        <form [formGroup]="ticketForm" (ngSubmit)="submitTicket()" class="space-y-6">
+            <!-- Contact Information -->
+            <div class="space-y-4">
+                <h2 class="text-xl font-semibold">Contact Information</h2>
+
+                <mat-form-field class="w-full" appearance="outline">
+                    <mat-label>Email Address</mat-label>
+                    <input matInput type="email" formControlName="email" placeholder="your.email@example.com">
+                    @if (ticketForm.get('email')?.invalid && ticketForm.get('email')?.touched) {
+                    <mat-error>{{ getErrorMessage('email') }}</mat-error>
+                    }
+                </mat-form-field>
+            </div>
+
+            <!-- Ticket Details -->
+            <div class="space-y-4">
+                <h2 class="text-xl font-semibold">Ticket Details</h2>
+
+                <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    <mat-form-field appearance="outline">
+                        <mat-label>Category</mat-label>
+                        <mat-select formControlName="category">
+                            @for (category of categories; track category.value) {
+                            <mat-option [value]="category.value">
+                                {{ category.label }}
+                            </mat-option>
+                            }
+                        </mat-select>
+                        @if (ticketForm.get('category')?.invalid && ticketForm.get('category')?.touched) {
+                        <mat-error>{{ getErrorMessage('category') }}</mat-error>
+                        }
+                    </mat-form-field>
+
+                    <mat-form-field appearance="outline">
+                        <mat-label>Priority</mat-label>
+                        <mat-select formControlName="priority">
+                            @for (priority of priorities; track priority.value) {
+                            <mat-option [value]="priority.value">
+                                {{ priority.label }}
+                            </mat-option>
+                            }
+                        </mat-select>
+                    </mat-form-field>
+                </div>
+
+                <mat-form-field class="w-full" appearance="outline">
+                    <mat-label>Subject</mat-label>
+                    <input matInput formControlName="subject" placeholder="Brief description of your issue">
+                    @if (ticketForm.get('subject')?.invalid && ticketForm.get('subject')?.touched) {
+                    <mat-error>{{ getErrorMessage('subject') }}</mat-error>
+                    }
+                </mat-form-field>
+
+                <mat-form-field class="w-full" appearance="outline">
+                    <mat-label>Description</mat-label>
+                    <textarea matInput formControlName="description" rows="8"
+                        placeholder="Please provide detailed information about your issue, including steps to reproduce, error messages, and what you've already tried...">
+                        </textarea>
+                    <mat-hint>{{ ticketForm.get('description')?.value?.length || 0 }} characters (minimum 20)</mat-hint>
+                    @if (ticketForm.get('description')?.invalid && ticketForm.get('description')?.touched) {
+                    <mat-error>{{ getErrorMessage('description') }}</mat-error>
+                    }
+                </mat-form-field>
+            </div>
+
+            <!-- Submit Button -->
+            <div class="flex items-center justify-end gap-4 pt-4">
+                <button type="button" mat-stroked-button [routerLink]="['/support']">
+                    Cancel
+                </button>
+                <button type="submit" mat-flat-button color="primary" [disabled]="isSubmitting">
+                    @if (isSubmitting) {
+                    <mat-icon class="mr-2 animate-spin" [svgIcon]="'heroicons_outline:arrow-path'"></mat-icon>
+                    Submitting...
+                    } @else {
+                    <mat-icon class="mr-2" [svgIcon]="'heroicons_outline:paper-airplane'"></mat-icon>
+                    Submit Ticket
+                    }
+                </button>
+            </div>
+        </form>
+        } @else {
+        <!-- Success Message -->
+        <div
+            class="bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800 p-8 text-center">
+            <mat-icon class="text-green-600 mx-auto mb-4" [svgIcon]="'heroicons_outline:check-circle'"
+                style="width: 64px; height: 64px;"></mat-icon>
+            <h2 class="text-2xl font-semibold mb-4">Ticket Submitted Successfully!</h2>
+            <p class="text-secondary mb-6">
+                Thank you for reaching out. We've received your support ticket and our team will respond to your email
+                within 24-48 hours.
+            </p>
+            <div class="flex justify-center gap-4">
+                <button mat-stroked-button [routerLink]="['/support']">
+                    Back to Support
+                </button>
+                <button mat-flat-button color="primary" (click)="submitted = false">
+                    Submit Another Ticket
+                </button>
+            </div>
+        </div>
+        }
+    </div>
+</div>

--- a/src/app/modules/support/ticket/ticket.component.ts
+++ b/src/app/modules/support/ticket/ticket.component.ts
@@ -1,0 +1,166 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { RouterLink } from '@angular/router';
+import { AuthService } from 'app/core/auth/auth.service';
+import { UserService } from 'app/core/user/user.service';
+import { environment } from 'environments/environment';
+
+@Component({
+    selector: 'app-ticket',
+    templateUrl: './ticket.component.html',
+    standalone: true,
+    imports: [
+        CommonModule,
+        ReactiveFormsModule,
+        MatButtonModule,
+        MatIconModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatSnackBarModule,
+        RouterLink
+    ]
+})
+export class TicketComponent implements OnInit {
+    ticketForm: FormGroup;
+    isAuthenticated = false;
+    isSubmitting = false;
+    submitted = false;
+
+    categories = [
+        { value: 'technical', label: 'Technical Issue' },
+        { value: 'account', label: 'Account Issue' },
+        { value: 'ability', label: 'Ability Issue' },
+        { value: 'keybind', label: 'Keybind Help' },
+        { value: 'macro', label: 'Macro Help' },
+        { value: 'feature', label: 'Feature Request' },
+        { value: 'bug', label: 'Bug Report' },
+        { value: 'other', label: 'Other' }
+    ];
+
+    priorities = [
+        { value: 'low', label: 'Low - General question' },
+        { value: 'medium', label: 'Medium - Need assistance' },
+        { value: 'high', label: 'High - Blocking issue' },
+        { value: 'urgent', label: 'Urgent - Critical problem' }
+    ];
+
+    constructor(
+        private _formBuilder: FormBuilder,
+        private _authService: AuthService,
+        private _userService: UserService,
+        private _snackBar: MatSnackBar,
+        private _http: HttpClient
+    ) {
+        this.ticketForm = this._formBuilder.group({
+            email: ['', [Validators.required, Validators.email]],
+            category: ['', Validators.required],
+            priority: ['medium', Validators.required],
+            subject: ['', [Validators.required, Validators.minLength(5)]],
+            description: ['', [Validators.required, Validators.minLength(20)]]
+        });
+    }
+
+    ngOnInit(): void {
+        this._authService.check().subscribe(authenticated => {
+            this.isAuthenticated = authenticated;
+
+            // Pre-fill email if authenticated
+            if (authenticated) {
+                this._userService.user$.subscribe(user => {
+                    if (user) {
+                        this.ticketForm.patchValue({
+                            email: user.email
+                        });
+                        // Make email field read-only for authenticated users
+                        this.ticketForm.get('email')?.disable();
+                    }
+                });
+            }
+        });
+    }
+
+    submitTicket(): void {
+        if (this.ticketForm.invalid) {
+            Object.keys(this.ticketForm.controls).forEach(key => {
+                this.ticketForm.get(key)?.markAsTouched();
+            });
+            return;
+        }
+
+        this.isSubmitting = true;
+
+        // Get form values (including disabled fields for authenticated users)
+        const ticketData = {
+            email: this.ticketForm.get('email')?.value || this.ticketForm.get('email')?.getRawValue(),
+            category: this.ticketForm.get('category')?.value,
+            priority: this.ticketForm.get('priority')?.value,
+            subject: this.ticketForm.get('subject')?.value,
+            description: this.ticketForm.get('description')?.value
+        };
+
+        // Call backend API
+        this._http.post(`${environment.apiUrl}/api/support/ticket`, ticketData)
+            .subscribe({
+                next: (response: any) => {
+                    this.isSubmitting = false;
+                    this.submitted = true;
+
+                    const issueKey = response.ticket?.issue_key || 'Your ticket';
+                    const message = response.ticket?.issue_key
+                        ? `Support ticket ${issueKey} submitted successfully! We'll get back to you soon.`
+                        : 'Support ticket submitted successfully! We\'ll get back to you soon.';
+
+                    this._snackBar.open(message, 'Close', {
+                        duration: 5000,
+                        horizontalPosition: 'center',
+                        verticalPosition: 'top',
+                        panelClass: ['success-snackbar']
+                    });
+
+                    // Reset form
+                    this.ticketForm.reset({
+                        priority: 'medium'
+                    });
+                },
+                error: (error) => {
+                    this.isSubmitting = false;
+
+                    const errorMessage = error.error?.message || 'Failed to submit ticket. Please try again.';
+
+                    this._snackBar.open(errorMessage, 'Close', {
+                        duration: 5000,
+                        horizontalPosition: 'center',
+                        verticalPosition: 'top',
+                        panelClass: ['error-snackbar']
+                    });
+                }
+            });
+    }
+
+    getErrorMessage(fieldName: string): string {
+        const field = this.ticketForm.get(fieldName);
+
+        if (field?.hasError('required')) {
+            return 'This field is required';
+        }
+        if (field?.hasError('email')) {
+            return 'Please enter a valid email address';
+        }
+        if (field?.hasError('minlength')) {
+            const minLength = field.errors?.['minlength'].requiredLength;
+            return `Minimum length is ${minLength} characters`;
+        }
+
+        return '';
+    }
+}
+


### PR DESCRIPTION
- Add support center landing page (/support)
- Add comprehensive FAQ page with 20+ questions in 5 categories
- Add support ticket submission form
- Integrate with backend Jira API (POST /api/support/ticket)
- Add question mark icon in header for support access
- Remove name field, only require email for tickets
- Add 8 ticket categories: technical, account, ability, keybind, macro, feature, bug, other
- Pre-fill email for authenticated users
- Add form validation and error handling
- Display Jira ticket number on successful submission
- Make support accessible to all users (authenticated and anonymous)

Components:
- SupportComponent: Main landing page with cards
- FaqComponent: FAQ with collapsible sections
- TicketComponent: Support ticket form with validation

Features:
- Beautiful UI with Material Design
- Real-time form validation
- Success/error notifications
- Rate limiting aware
- Responsive design