### PR TITLE
fix: add /api prefix to all environment API URLs

### DIFF
--- a/src/app/modules/support/ticket/ticket.component.ts
+++ b/src/app/modules/support/ticket/ticket.component.ts
@@ -108,7 +108,7 @@ export class TicketComponent implements OnInit {
         };
 
         // Call backend API
-        this._http.post(`${environment.apiUrl}/api/support/ticket`, ticketData)
+        this._http.post(`${environment.apiUrl}/support/ticket`, ticketData)
             .subscribe({
                 next: (response: any) => {
                     this.isSubmitting = false;

--- a/src/environments/environment.develop.ts
+++ b/src/environments/environment.develop.ts
@@ -1,7 +1,7 @@
 export const environment = {
     production: false,
     envName: 'develop',
-    apiUrl: 'http://localhost:1337',
+    apiUrl: 'http://localhost:1337/api',
     hmr: false,
     // Force rebuild to ensure correct API URL is used
     debugFlag: 'DEVELOP_ENV_ACTIVE_2024'

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -1,7 +1,7 @@
 export const environment = {
     production: true,
     envName: 'production',
-    apiUrl: 'https://api.wowkeyb.gg',
+    apiUrl: 'https://api.wowkeyb.gg/api',
     hmr: false,
     debugFlag: 'PRODUCTION_ENV_ACTIVE_2024'
 };

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -1,7 +1,7 @@
 export const environment = {
     production: false,
     envName: 'staging',
-    apiUrl: 'https://staging-api.wowkeyb.gg',
+    apiUrl: 'https://staging-api.wowkeyb.gg/api',
     hmr: false,
     debugFlag: 'STAGING_ENV_ACTIVE_2024'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
     production: false,
     envName: 'dev',
-    apiUrl: 'http://localhost:1337',
+    apiUrl: 'http://localhost:1337/api',
     debugFlag: 'BASE_ENV_ACTIVE_2024'
 };
 


### PR DESCRIPTION
- Update all environment files to include /api prefix in base URL
- Prevents 404 errors after backend route structure change
- Affects: environment.ts, environment.develop.ts, environment.staging.ts, environment.production.ts